### PR TITLE
Update 0600 icon guidance to lucide-react

### DIFF
--- a/0600-next-context-api/README.md
+++ b/0600-next-context-api/README.md
@@ -75,5 +75,4 @@ https://www.netlify.com/
     - [ ] タスク一覧画面(tasks)の実装。
     - [ ] プロジェクト一覧画面(tasks)の実装。
 
-各種アイコンにはこちらの　[react-icons | ionicon5] (https://react-icons.github.io/react-icons/icons/io5/) を使用しています。
-
+各種アイコンにはこちらの [lucide-react](https://lucide.dev/icons/) を使用しています。


### PR DESCRIPTION
# 0600 課題 README のアイコン案内を lucide-react に更新

## Summary
0600 の Next.js / Context API 課題 README で、アイコンライブラリの案内を `react-icons` から `lucide-react` に変更しました。

**主な変更点:**
- `react-icons | ionicon5` の案内を削除
- `lucide-react` のアイコン一覧へのリンクに差し替え
- Markdown リンク表記を整備

## やったこと
- `0600-next-context-api/README.md` のアイコン利用案内を更新

## 動作確認
- [x] `git diff origin/main...HEAD` で README の差分を確認
- [x] `rg -n "react-icons|lucide-react" 0600-next-context-api/README.md` で参照先を確認
- [x] 作業ツリーが clean であることを確認

## レビュー & 動作確認 チェックリスト
- [ ] **案内先** - `lucide-react` のリンクが意図した案内先になっていること
- [ ] **変更範囲** - README の該当案内以外に不要な変更が含まれていないこと

**推奨テスト計画:**
1. README の該当箇所を表示する
2. `lucide-react` のリンク先を開く
3. 旧 `react-icons` 案内が残っていないことを確認する

## その他気になることや相談ごと
特になし
