### PR TITLE
test: OpenAPIレスポンススキーマ検証を追加

### DIFF
--- a/0700-express-web-api/test/tests/auth.test.ts
+++ b/0700-express-web-api/test/tests/auth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { expectAuthData } from "./support/contracts";
+import {
+  expectAuthData,
+  expectCompleteAuth,
+  expectCompleteDataResponse,
+  expectCompleteError
+} from "./support/contracts";
 import { apiRequest } from "./support/http";
 import { seedUser } from "./testData";
 
@@ -16,6 +21,19 @@ describe("POST /auth/login", () => {
 
       expect(response.status).toBe(200);
       expectAuthData(response.body.data);
+    });
+
+    it("レスポンスが OpenAPI スキーマに適合する", async () => {
+      const response = await apiRequest("/auth/login", {
+        method: "POST",
+        body: JSON.stringify({
+          email: seedUser.email,
+          password: seedUser.password
+        })
+      });
+
+      expect(response.status).toBe(200);
+      expectCompleteDataResponse(response.body, expectCompleteAuth);
     });
   });
 
@@ -53,6 +71,23 @@ describe("POST /auth/signup", () => {
       expect(response.status).toBe(200);
       expectAuthData(response.body.data);
     });
+
+    it("レスポンスが OpenAPI スキーマに適合する", async () => {
+      const unique = `schema-test-${Date.now()}-${crypto.randomUUID()}@example.com`;
+      const response = await apiRequest("/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          username: "api-schema-test-user",
+          email: unique,
+          email_confirmation: unique,
+          password: "password",
+          password_confirmation: "password"
+        })
+      });
+
+      expect(response.status).toBe(200);
+      expectCompleteDataResponse(response.body, expectCompleteAuth);
+    });
   });
 
   describe("異常系", () => {
@@ -69,6 +104,22 @@ describe("POST /auth/signup", () => {
       });
 
       expect(response.status).toBe(409);
+    });
+
+    it("409 レスポンスが OpenAPI スキーマに適合する", async () => {
+      const response = await apiRequest("/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          username: "duplicate-schema-test-user",
+          email: seedUser.email,
+          email_confirmation: seedUser.email,
+          password: "password",
+          password_confirmation: "password"
+        })
+      });
+
+      expect(response.status).toBe(409);
+      expectCompleteError(response.body);
     });
   });
 });

--- a/0700-express-web-api/test/tests/projects.test.ts
+++ b/0700-express-web-api/test/tests/projects.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { expectPageInfo } from "./support/assertions";
-import { Project, expectProject } from "./support/contracts";
+import {
+  Project,
+  expectCompleteDataResponse,
+  expectCompletePageResponse,
+  expectCompleteProject,
+  expectProject
+} from "./support/contracts";
 import { apiRequestWithToken, loginAsSeedUser } from "./support/http";
 import { missingProjectSlug, seedProject, seedProjects } from "./testData";
 
@@ -34,6 +40,17 @@ describe("GET /users/projects", () => {
         expect(response.body.data.length).toBeLessThanOrEqual(1);
         expectPageInfo(response.body.pageInfo, { limit: 1, page: 1 });
         response.body.data.forEach(expectProject);
+      });
+
+      it("レスポンスが OpenAPI スキーマに適合する", async () => {
+        const token = await loginAsSeedUser();
+        const response = await apiRequestWithToken(
+          "/users/projects?limit=20&page=1",
+          token
+        );
+
+        expect(response.status).toBe(200);
+        expectCompletePageResponse(response.body, expectCompleteProject);
       });
 
       it("3 ページに分けて順番通りに取得できる", async () => {
@@ -71,6 +88,17 @@ describe("GET /users/projects/:slug", () => {
           slug: seedProject.slug
         })
       );
+    });
+
+    it("レスポンスが OpenAPI スキーマに適合する", async () => {
+      const token = await loginAsSeedUser();
+      const response = await apiRequestWithToken(
+        `/users/projects/${seedProject.slug}`,
+        token
+      );
+
+      expect(response.status).toBe(200);
+      expectCompleteDataResponse(response.body, expectCompleteProject);
     });
   });
 

--- a/0700-express-web-api/test/tests/support/assertions.ts
+++ b/0700-express-web-api/test/tests/support/assertions.ts
@@ -6,6 +6,11 @@ const uuidPattern =
 const isoDateTimePattern =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 
+const openApiDateTimePattern =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export function expectUuid(value: unknown): asserts value is string {
   expect(value).toEqual(expect.any(String));
   expect(value).toMatch(uuidPattern);
@@ -14,6 +19,51 @@ export function expectUuid(value: unknown): asserts value is string {
 export function expectNonEmptyString(value: unknown): asserts value is string {
   expect(value).toEqual(expect.any(String));
   expect((value as string).length).toBeGreaterThan(0);
+}
+
+export function expectString(value: unknown): asserts value is string {
+  expect(value).toEqual(expect.any(String));
+}
+
+export function expectEmail(value: unknown): asserts value is string {
+  expectString(value);
+  expect(value).toMatch(emailPattern);
+}
+
+export function expectIsoDateTime(value: unknown): asserts value is string {
+  expectString(value);
+  expect(value).toMatch(openApiDateTimePattern);
+  expect(Number.isNaN(Date.parse(value))).toBe(false);
+}
+
+export function expectInteger(value: unknown): asserts value is number {
+  expect(value).toEqual(expect.any(Number));
+  expect(Number.isInteger(value)).toBe(true);
+}
+
+export function expectBoolean(value: unknown): asserts value is boolean {
+  expect(value).toEqual(expect.any(Boolean));
+}
+
+export function expectRecord(value: unknown): asserts value is Record<string, unknown> {
+  expect(value).not.toBeNull();
+  expect(Array.isArray(value)).toBe(false);
+  expect(typeof value).toBe("object");
+}
+
+export function expectSchemaProperty(
+  object: Record<string, unknown>,
+  property: string,
+  expectValue: (value: unknown) => void
+): void {
+  expect(Object.hasOwn(object, property), `property ${property} が存在しません`).toBe(true);
+
+  const value = object[property];
+  expect(value, `property ${property} に undefined は指定できません`).not.toBeUndefined();
+
+  if (value !== null) {
+    expectValue(value);
+  }
 }
 
 export function expectOptionalIsoDateTime(value: unknown): void {

--- a/0700-express-web-api/test/tests/support/contracts.ts
+++ b/0700-express-web-api/test/tests/support/contracts.ts
@@ -1,9 +1,16 @@
 import { expect } from "vitest";
 import {
+  expectBoolean,
+  expectEmail,
+  expectInteger,
+  expectIsoDateTime,
   expectNonEmptyString,
   expectOptionalInteger,
   expectOptionalIsoDateTime,
   expectOptionalString,
+  expectRecord,
+  expectSchemaProperty,
+  expectString,
   expectUuid
 } from "./assertions";
 
@@ -44,6 +51,148 @@ export type Task = {
   status: "scheduled" | "completed" | "archived";
   project?: Project;
 };
+
+type SchemaAssertion = (value: unknown) => void;
+
+const projectSchema = {
+  id: expectUuid,
+  name: expectString,
+  slug: expectString,
+  goal: expectString,
+  shouldbe: expectString,
+  color: expectString,
+  stats: expectCompleteProjectStats,
+  createdAt: expectIsoDateTime,
+  updatedAt: expectIsoDateTime,
+  deadline: expectIsoDateTime,
+  startingAt: expectIsoDateTime,
+  startedAt: expectIsoDateTime,
+  finishedAt: expectIsoDateTime
+} satisfies Record<string, SchemaAssertion>;
+
+const taskStatusPattern = /^(scheduled|completed|archived)$/;
+
+function expectCompleteObject(
+  value: unknown,
+  schema: Record<string, SchemaAssertion>
+): void {
+  expectRecord(value);
+
+  for (const [property, expectValue] of Object.entries(schema)) {
+    expectSchemaProperty(value, property, expectValue);
+  }
+}
+
+export function expectCompleteAuth(value: unknown): void {
+  expectCompleteObject(value, {
+    uuid: expectUuid,
+    accessToken: expectString,
+    refreshToken: expectString
+  });
+}
+
+export function expectCompleteUser(value: unknown): void {
+  expectCompleteObject(value, {
+    id: expectUuid,
+    username: expectString,
+    email: expectEmail,
+    status: (status) => {
+      expectString(status);
+      expect(status).toMatch(/^(active|deactive)$/);
+    }
+  });
+}
+
+export function expectCompleteProject(value: unknown): void {
+  expectCompleteObject(value, projectSchema);
+}
+
+function expectCompleteProjectStats(value: unknown): void {
+  expectCompleteObject(value, {
+    total: expectInteger,
+    kinds: expectCompleteProjectStatsKinds,
+    states: expectCompleteProjectStatsStates
+  });
+}
+
+function expectCompleteProjectStatsKinds(value: unknown): void {
+  expectCompleteObject(value, {
+    milestone: expectInteger,
+    task: expectInteger,
+    total: expectInteger
+  });
+}
+
+function expectCompleteProjectStatsStates(value: unknown): void {
+  expectCompleteObject(value, {
+    scheduled: expectInteger,
+    completed: expectInteger,
+    archived: expectInteger
+  });
+}
+
+export function expectCompleteTask(value: unknown): void {
+  expectCompleteObject(value, {
+    id: expectUuid,
+    title: expectString,
+    description: expectString,
+    status: (status) => {
+      expectString(status);
+      expect(status).toMatch(taskStatusPattern);
+    },
+    createdAt: expectIsoDateTime,
+    updatedAt: expectIsoDateTime,
+    finishedAt: expectIsoDateTime,
+    startedAt: expectIsoDateTime,
+    archivedAt: expectIsoDateTime,
+    startingAt: expectIsoDateTime,
+    deadline: expectIsoDateTime,
+    project: expectCompleteProject,
+    parent: expectCompleteTask,
+    children: (children) => {
+      expect(Array.isArray(children)).toBe(true);
+      (children as unknown[]).forEach(expectCompleteTask);
+    }
+  });
+}
+
+export function expectCompletePageInfo(value: unknown): void {
+  expectCompleteObject(value, {
+    totalCount: expectInteger,
+    limit: expectInteger,
+    page: expectInteger,
+    hasNext: expectBoolean,
+    hasPrevious: expectBoolean
+  });
+}
+
+export function expectCompleteError(value: unknown): void {
+  expectCompleteObject(value, {
+    message: expectString
+  });
+}
+
+export function expectCompleteDataResponse(
+  value: unknown,
+  expectData: SchemaAssertion
+): void {
+  expectCompleteObject(value, {
+    data: expectData
+  });
+}
+
+export function expectCompletePageResponse(
+  value: unknown,
+  expectItem: SchemaAssertion
+): void {
+  expectCompleteObject(value, {
+    data: (data) => {
+      expect(Array.isArray(data)).toBe(true);
+      (data as unknown[]).forEach(expectItem);
+    },
+    pageInfo: expectCompletePageInfo
+  });
+}
 
 export function expectAuthData(value: unknown): void {
   expect(value).toEqual(

--- a/0700-express-web-api/test/tests/tasks.test.ts
+++ b/0700-express-web-api/test/tests/tasks.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { expectPageInfo } from "./support/assertions";
-import { Project, Task, expectProject, expectTask } from "./support/contracts";
+import {
+  Project,
+  Task,
+  expectCompleteDataResponse,
+  expectCompletePageResponse,
+  expectCompleteTask,
+  expectProject,
+  expectTask
+} from "./support/contracts";
 import { apiRequestWithToken, loginAsSeedUser } from "./support/http";
 import { missingProjectId, missingTaskId, seedProject } from "./testData";
 
@@ -133,6 +141,17 @@ describe("GET /users/tasks", () => {
       });
     });
 
+    it("レスポンスが OpenAPI スキーマに適合する", async () => {
+      const token = await loginAsSeedUser();
+      const response = await apiRequestWithToken(
+        "/users/tasks?limit=20&page=1&status=scheduled",
+        token
+      );
+
+      expect(response.status).toBe(200);
+      expectCompletePageResponse(response.body, expectCompleteTask);
+    });
+
     describe("ページネーション", () => {
       it("3 ページに分けて取得できる", async () => {
         const token = await loginAsSeedUser();
@@ -251,6 +270,21 @@ describe("GET /users/tasks/:id", () => {
         await deleteTask(token, task.id);
       }
     });
+
+    it("レスポンスが OpenAPI スキーマに適合する", async () => {
+      const token = await loginAsSeedUser();
+      const project = await getSeedProject(token);
+      const task = await createTask(token, project.id);
+
+      try {
+        const response = await apiRequestWithToken(`/users/tasks/${task.id}`, token);
+
+        expect(response.status).toBe(200);
+        expectCompleteDataResponse(response.body, expectCompleteTask);
+      } finally {
+        await deleteTask(token, task.id);
+      }
+    });
   });
 
   describe("異常系", () => {
@@ -299,6 +333,24 @@ describe("PATCH /users/tasks/:id", () => {
             status: "completed"
           })
         );
+      } finally {
+        await deleteTask(token, task.id);
+      }
+    });
+
+    it("レスポンスが OpenAPI スキーマに適合する", async () => {
+      const token = await loginAsSeedUser();
+      const project = await getSeedProject(token);
+      const task = await createTask(token, project.id);
+
+      try {
+        const response = await apiRequestWithToken(`/users/tasks/${task.id}`, token, {
+          method: "PATCH",
+          body: JSON.stringify(createTaskPayload(project.id, { status: "completed" }))
+        });
+
+        expect(response.status).toBe(200);
+        expectCompleteDataResponse(response.body, expectCompleteTask);
       } finally {
         await deleteTask(token, task.id);
       }
@@ -364,6 +416,18 @@ describe("DELETE /users/tasks/:id", () => {
           id: task.id
         })
       );
+    });
+
+    it("レスポンスが OpenAPI スキーマに適合する", async () => {
+      const token = await loginAsSeedUser();
+      const project = await getSeedProject(token);
+      const task = await createTask(token, project.id);
+      const response = await apiRequestWithToken(`/users/tasks/${task.id}`, token, {
+        method: "DELETE"
+      });
+
+      expect(response.status).toBe(200);
+      expectCompleteDataResponse(response.body, expectCompleteTask);
     });
   });
 

--- a/0700-express-web-api/test/tests/user.test.ts
+++ b/0700-express-web-api/test/tests/user.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { expectUser } from "./support/contracts";
+import {
+  expectCompleteDataResponse,
+  expectCompleteUser,
+  expectUser
+} from "./support/contracts";
 import { apiRequest, apiRequestWithToken, loginAsSeedUser } from "./support/http";
 import { seedUser } from "./testData";
 
@@ -19,6 +23,14 @@ describe("GET /users/me", () => {
           status: seedUser.status
         })
       );
+    });
+
+    it("レスポンスが OpenAPI スキーマに適合する", async () => {
+      const token = await loginAsSeedUser();
+      const response = await apiRequestWithToken("/users/me", token);
+
+      expect(response.status).toBe(200);
+      expectCompleteDataResponse(response.body, expectCompleteUser);
     });
   });
 


### PR DESCRIPTION
# OpenAPIレスポンススキーマ検証の追加

## Summary
Express Web API のレスポンスが、参照 OpenAPI で定義された全プロパティを含み、非 null 値が定義済みの型・形式へ適合することを検証するテストを追加します。

**主な変更点:**
- 全プロパティのキー存在と `undefined` の拒否を検証
- 非 null 値の型、UUID、email、date-time、integer、enum を検証
- Project・Task のネストしたスキーマを再帰的に検証

## やったこと
- 既存の振る舞いテストとは別に、OpenAPI スキーマ適合テストを10件追加
- Auth、User、Project、ProjectStats、Task、PageInfo、Error の共通検証関数を追加
- `additionalProperties: false` がないため、OpenAPI 未定義の追加プロパティは許可
- レスポンススキーマが定義されていない `POST /users/tasks` の201、および schema のないエラー応答は対象外

## 動作確認
- [x] `npm run typecheck`
- [x] `git diff --check`
- [ ] `npm test`（テスト対象サーバーが `http://localhost:3000` で起動していないため、setup の接続確認で停止）

## レビュー & 動作確認 チェックリスト
- [ ] **全キーの存在** - OpenAPI に定義された各プロパティのキー欠損を検出できること
- [ ] **null と型制約** - null は許可し、非 null 値では型・format・enumを検証すること
- [ ] **再帰スキーマ** - Task の parent・children と Project を同じ契約で検証すること

**推奨テスト計画:**
1. 学習者サーバーで `npm run db:seed` と `npm run dev` を実行する
2. このテストプロジェクトで `npm test` を実行する
3. スキーマ検証ケースの失敗時に、欠損プロパティ名または型違反が表示されることを確認する

## その他気になることや相談ごと
OpenAPI の Task スキーマには `required: [name]` とプロパティ単位の `required: true` が混在しています。本変更では合意したテスト契約に従い、required 記法にかかわらず定義済みの全プロパティキーを要求します。
